### PR TITLE
docs: ajuste na documentação do guia na pasta publicar. O problema er…

### DIFF
--- a/docs/byron-docs/guia/7-publicar/index.mdx
+++ b/docs/byron-docs/guia/7-publicar/index.mdx
@@ -15,10 +15,10 @@ Depois de ser adicionado como colaborador, faça uma nova branch com as suas alt
 git checkout -b nome_da_branch
 ```
 
-O nome para a branch deverá ser `diretoria/processo`. Por exemplo, no caso da inclusão do processo de Fluxo de caixa para DVP, o nome da branch seria `dvp/fluxo-de-caixa`. Então, o comando seria:
+O nome para a branch deverá ser `diretoria-processo`. Por exemplo, no caso da inclusão do processo de Fluxo de caixa para DVP, o nome da branch seria `dvp-fluxo-de-caixa`. Então, o comando seria:
 
 ```bash
-git checkout -b dvp/fluxo-de-caixa
+git checkout -b dvp-fluxo-de-caixa
 ```
 
 Feito isso, faça um _commit_ e um _push_ de suas alterações:


### PR DESCRIPTION
…a que as branches que possuiam o nome da diretoria/processo não conseguiam ser atualizadas no repositório por isso substitui o caracter '/' pelo '-', assim é possível fazer o push e criar novas branches.